### PR TITLE
ADD: 新增内部错误异常，用于「重试」上传请求

### DIFF
--- a/lib/lark.rb
+++ b/lib/lark.rb
@@ -16,6 +16,7 @@ module Lark
   class AppNotConfigException < RuntimeError; end
   class AccessTokenExpiredError < RuntimeError; end
   class ResultErrorException < RuntimeError; end
+  class InternalErrorException < RuntimeError; end
   class ResponseError < StandardError
     attr_reader :error_code
     def initialize(errcode, errmsg='')

--- a/lib/lark/request.rb
+++ b/lib/lark/request.rb
@@ -48,6 +48,7 @@ module Lark
       header['Accept'] = 'application/json'
       header['X-Request-ID'] = request_uuid
       response = yield(url, header)
+      Lark.logger.info "response headers: #{response.headers.inspect}"
       unless response.status.success?
         Lark.logger.error "request #{url} happen error: #{response.body}"
         raise ResponseError.new(response.status, response.body)

--- a/lib/lark/request.rb
+++ b/lib/lark/request.rb
@@ -78,7 +78,8 @@ module Lark
       Lark.logger.info "response body: #{body}"
       data = JSON.parse body.to_s
       result = Result.new(data)
-      raise ::Lark::AccessTokenExpiredError if [99_991_663, 99_991_664].include?(result.code)
+      raise ::Lark::AccessTokenExpiredError if result.access_token_expired?
+      raise ::Lark::InternalErrorException if result.internal_error?
 
       result
     end
@@ -99,6 +100,14 @@ module Lark
     def initialize(data)
       @code = data['code'].to_i
       @data = data
+    end
+
+    def access_token_expired?
+      [99_991_663, 99_991_664].include?(code)
+    end
+
+    def internal_error?
+      [1_061_001, 1_061_006, 1_061_045].include?(code)
     end
 
     def success?


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1230025/148195090-8a0a7018-ecd2-432b-8bff-5905117aa4b8.png)
![image](https://user-images.githubusercontent.com/1230025/148195127-20091172-3ef7-4b2f-a66f-a057c99abcf1.png)
![image](https://user-images.githubusercontent.com/1230025/148195161-f2f6e823-f212-4be9-ab89-40755f2633bd.png)

这几个错误都是以 HTTP 状态码 200 返回的，API 那边需要根据异常来重试上传，所以这几个「错误码」得抛出去。